### PR TITLE
Fix punctuation in README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # HPCX Ondemand documentation
-This is a user documentation for HPCX Ondemand at the University
+This is a user documentation for HPCX Ondemand at the University.


### PR DESCRIPTION
There should be a full stop at the end.